### PR TITLE
[marathon] Add two config flags that enable new features:

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -54,11 +54,11 @@ class Marathon(AgentCheck):
         timeout = float(instance.get('timeout', default_timeout))
         group_tags = instance.get('group_tags', self.DEFAULT_GROUP_TAGS)
         track_health = instance.get('track_health', self.DEFAULT_TRACK_HEALTH)
-        
+
         if track_health and not self.HEALTH_METRICS_ADDED:
             self.APP_METRICS.append('tasksHealthy')
             self.APP_METRICS.append('tasksUnhealthy')
-            HEALTH_METRICS_ADDED = True
+            self.HEALTH_METRICS_ADDED = True
 
         # Marathon apps
         response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -9,3 +9,16 @@ instances:
   #   if marathon is protected by basic auth
   #   user: "username"
   #   password: "password"
+  #   
+  #   Optionally split applications into their groups and names. When enabled,
+  #   the app_id is separated from it's group using the last back-slash. E.g.
+  #   if the app_id is "/dev/redis" then the metric will now have two tags:
+  #        app_id:redis group:/dev
+  #   Note that if the application does not have a group, the group tag will be
+  #   root or group:/
+  #   
+  #   group_tags: True
+  #
+  #   Optionally track the "tasksHealthy" and "tasksUnHealthy" metrics per app.
+  #
+  #   track_health: True


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?

group_tags: to split the application ID into an app ID and the group
it belongs to.
track_health: Enable recording of the "tasksHealthy" and "tasksUnhealthy"
metrics per app.